### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/appeler/instate/security/code-scanning/4](https://github.com/appeler/instate/security/code-scanning/4)

To fix the problem, add a `permissions` block to the relevant scope of the GitHub Actions workflow. Since none of the steps require write access, set the minimum permissions (preferably at the top-level of the workflow for all jobs, unless specific jobs need more). The block should specify `contents: read` to restrict the `GITHUB_TOKEN` to only have read access to repository contents. To implement this, insert the following block immediately after the `name:` entry and prior to `on:` (typically near the top of the workflow file).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
