### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/adjacent_repo_recommender.yaml
+++ b/.github/workflows/adjacent_repo_recommender.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   recommend-repos:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/appeler/instate/security/code-scanning/2](https://github.com/appeler/instate/security/code-scanning/2)

To fix the problem, explicitly specify a `permissions` block at the job (or workflow) level. Analyze the required minimal permissions for the workflow: the use of `git push` requires `contents: write`. If pull requests were being created, we might also need `pull-requests: write`, but none are seen here. Thus, only `contents: write` is necessary for this job. Place a `permissions` key under the `recommend-repos` job, aligning it at the same indentation as `runs-on`. No other changes are needed in other files or steps. This maintains least privilege for the job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
